### PR TITLE
Allow disabling LED usage in config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= -lnx -lmpg123 -lm 
+LIBS	:= -lnx -lm 
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/sd_card/config/sys-ftpd/config.ini
+++ b/sd_card/config/sys-ftpd/config.ini
@@ -15,3 +15,9 @@ anonymous:=1
 [Pause]
 disabled:=0
 keycombo:=PLUS+MINUS+X
+
+[LED]
+led:=1
+
+# led:=1 -> LED flashes on connect (default)
+# led:=0 -> LED does not flash on connect


### PR DESCRIPTION
Heyo,

I plan to have a cronjob running on a homeserver to get me an album of the screenshots I take, and having the LED flash every minute or so would make it pretty annoying, so I implemented the ability to disable the LED flashing in config.

I've tested this and well, it works.

I've also:
- Dropped mpg123 requirement. This isn't required anymore as sys-ftpd has no audio playback.
- Moved connect LED action to only when there's a successful authentication, so that random unsuccessful connections (if they do happen) won't cause any flashing. (This change also makes it easier to integrate it into my modifications.)